### PR TITLE
chore(deps): move @types/node to dev deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
     "@babel/core": "^7.15.8",
     "@babel/eslint-parser": "^7.15.4",
     "@babel/preset-react": "^7.14.5",
-    "@types/node": "^16.7.13",
     "@typescript-eslint/eslint-plugin": "^4.31.0",
     "@typescript-eslint/parser": "^4.31.0",
     "eslint": "^7.32.0",
@@ -37,6 +36,9 @@
     "eslint-plugin-react": "^7.25.1",
     "eslint-plugin-react-hooks": "^4.2.0",
     "prettier": "^2.3.2"
+  },
+  "devDependencies": {
+    "@types/node": "^16.7.13"
   },
   "scripts": {
     "lint": "eslint .",


### PR DESCRIPTION
@types/* packages should be placed in dev deps because they are on used in runtime.